### PR TITLE
Update package.json to allow for local Ceramic daemon config

### DIFF
--- a/templates/composedb-profile/package.json
+++ b/templates/composedb-profile/package.json
@@ -6,6 +6,7 @@
     "dev": "node scripts/run.mjs",
     "nextDev": "next dev",
     "ceramic": "CERAMIC_ENABLE_EXPERIMENTAL_COMPOSE_DB='true' npx ceramic daemon --config ./composedb.config.json",
+    "ceramic:local": "CERAMIC_ENABLE_EXPERIMENTAL_COMPOSE_DB='true' npx ceramic daemon",
     "build": "next build",
     "start": "next start",
     "lint": "next lint"


### PR DESCRIPTION
Current use-case allows for the shipped `composedb.config.json` file to be used.  This is great if I'm starting with this tool, but if I have done some data modeling outside of this then I probably already have a Ceramic node instance I would like to use.

This PR adds a script that can be run to specify this behavior.