### PR TITLE
Allow Users to use either their globally or local Ceramic Configuration

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ceramicnetwork/create-ceramic-app",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "oclif example Hello World CLI",
   "author": "3Box Labs",
   "bin": {

--- a/templates/composedb-profile/README.md
+++ b/templates/composedb-profile/README.md
@@ -6,6 +6,12 @@ First, run the development server:
 npm run dev
 ```
 
+If you have already configured a Ceramic node that you'd rather use please use the following command:
+
+```bash
+npm run dev -- -g
+```
+
 Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
 
 ## Learn More

--- a/templates/composedb-profile/scripts/run.mjs
+++ b/templates/composedb-profile/scripts/run.mjs
@@ -6,8 +6,18 @@ import { writeComposite } from './composites.mjs';
 
 const events = new EventEmitter()
 const spinner = ora();
+const args = process.argv.slice(2)
 
-const ceramic = spawn("npm", ["run", "ceramic"]);
+let ceramic
+
+console.log(process.argv)
+
+if(args.includes('-g') || args.includes('--global')) {
+  ceramic = spawn("npm", ["run", `ceramic:local`]);
+} else {
+  ceramic = spawn("npm", ["run", `ceramic ${args.includes('-l')}`]);
+}
+
 ceramic.stdout.on("data", (buffer) => {
   console.log('[Ceramic]', buffer.toString())
   if (buffer.toString().includes("0.0.0.0:7007")) {

--- a/templates/composedb-profile/scripts/run.mjs
+++ b/templates/composedb-profile/scripts/run.mjs
@@ -10,8 +10,6 @@ const args = process.argv.slice(2)
 
 let ceramic
 
-console.log(process.argv)
-
 if(args.includes('-g') || args.includes('--global')) {
   ceramic = spawn("npm", ["run", `ceramic:local`]);
 } else {


### PR DESCRIPTION
Small update to allow users to run ceramic using their global configuration file based off of a flag (using either `-g` or `--global`)